### PR TITLE
WIP: Tests for tasks

### DIFF
--- a/server/controller/milestoneController.js
+++ b/server/controller/milestoneController.js
@@ -142,6 +142,8 @@ function createMilestone(request, reply) {
             reply(Boom.internal(error));
         }); //storage.createMilestone
 
+    }).catch(function(err) {
+        reply(Boom.notFound(err));
     }) // getProjectsOfUser
 }
 

--- a/server/controller/milestoneController.js
+++ b/server/controller/milestoneController.js
@@ -46,10 +46,6 @@ function updateMilestone(request, reply) {
     }
 
     storage.findProjectOfMilestone(milestone_id).then(function(result) {
-        if (!result) {
-            reply(Boom.badRequest(format(constants.MILESTONE_NOT_EXIST, milestone_id)));
-            return
-        }
         var project = result.project
         var github_num = result.milestone.github_number
 
@@ -91,7 +87,9 @@ function updateMilestone(request, reply) {
                 reply(Boom.internal(error));
             });
         })
-    })
+    }).catch(() => {
+        reply(Boom.badRequest(format(constants.MILESTONE_NOT_EXIST, milestone_id)));
+    });
 }
 
 function createMilestone(request, reply) {

--- a/server/controller/milestoneController.js
+++ b/server/controller/milestoneController.js
@@ -151,11 +151,6 @@ function deleteMilestone(request, reply) {
     var user_id = request.auth.credentials.user_id
 
     storage.findProjectOfMilestone(milestone_id).then(function(result) {
-        if (!result) {
-            reply(Boom.badRequest(format(constants.MILESTONE_NOT_EXIST, milestone_id)));
-            return
-        }
-
         var project = result.project
         var milestone = result.milestone
 
@@ -181,5 +176,7 @@ function deleteMilestone(request, reply) {
                 github.deleteGithubMilestone(project.github_repo_owner, project.github_repo_name, token, milestone.github_number)
             });
         })
-    })
+    }).catch(function(err) {
+        reply(Boom.badRequest(format(constants.MILESTONE_NOT_EXIST, milestone_id)));
+    });
 }

--- a/server/controller/projectController.js
+++ b/server/controller/projectController.js
@@ -165,6 +165,8 @@ function inviteToProject(request, reply) {
                 return reply(Boom.badRequest(errorMessage))
             })
         })
+    }).catch((error) => {
+        reply(Boom.forbidden(constants.FORBIDDEN));
     });
 }
 

--- a/server/controller/taskController.js
+++ b/server/controller/taskController.js
@@ -65,10 +65,6 @@ function updateTask(request, reply) {
     request.payload.completed_on = request.payload.completed_on ? request.payload.completed_on : null // convert empty string to null
 
     storage.findProjectOfTask(task_id).then(function(result) {
-        if (!result) {
-            reply(Boom.badRequest(format(constants.TASK_NOT_EXIST, task_id)));
-            return
-        }
         var project = result.project
         accessControl.isUserPartOfProject(user_id, project.id).then(function (isPartOf) {
             if (!isPartOf) {
@@ -117,6 +113,8 @@ function updateTask(request, reply) {
                 }
             })
         })
+    }).catch(function(err) {
+        reply(Boom.badRequest(err));
     })
 }
 
@@ -232,10 +230,6 @@ function markTaskAsDone(request, reply) {
     var user_id = request.auth.credentials.user_id
 
     storage.findProjectOfTask(task_id).then(function(result) {
-        if (!result) {
-            reply(Boom.badRequest(format(constants.TASK_NOT_EXIST, task_id)));
-            return
-        }
         var project = result.project
         accessControl.isUserPartOfProject(user_id, project.id).then(function (isPartOf) {
             if (!isPartOf) {
@@ -265,17 +259,15 @@ function markTaskAsDone(request, reply) {
                 })
             });
         })
-    })
+    }).catch(function(err) {
+        reply(Boom.badRequest(err));
+    });
 }
 
 function deleteTask(request, reply) {
     var user_id = request.auth.credentials.user_id
     var task_id = request.params.task_id;
     storage.findProjectOfTask(task_id).then(function(result) {
-        if (!result) {
-            reply(Boom.badRequest(format(constants.TASK_NOT_EXIST, task_id)));
-            return
-        }
         var project = result.project
         accessControl.isUserPartOfProject(user_id, project.id).then(function (isPartOf) {
             if (!isPartOf) {
@@ -296,6 +288,8 @@ function deleteTask(request, reply) {
                     status: constants.STATUS_OK
                 });
             });
-        })
-    })
+        });
+    }).catch(function(err) {
+        reply(Boom.badRequest(err));
+    });
 }

--- a/server/controller/taskController.js
+++ b/server/controller/taskController.js
@@ -125,10 +125,6 @@ function getTask(request, reply) {
     var user_id = request.auth.credentials.user_id
 
     storage.findProjectOfTask(task_id).then(function(result) {
-        if (!result) {
-            reply(Boom.badRequest(format(constants.TASK_NOT_EXIST, task_id)));
-            return
-        }
         var project = result.project
         accessControl.isUserPartOfProject(user_id, project.id).then(function (isPartOf) {
             if (!isPartOf) {
@@ -139,7 +135,9 @@ function getTask(request, reply) {
                 reply(task);
             });
         })
-    })
+    }).catch(function(err) {
+        reply(Boom.badRequest(err));
+    });
 }
 
 function createTask(request, reply) {

--- a/server/controller/userController.js
+++ b/server/controller/userController.js
@@ -132,5 +132,7 @@ function populate(request, reply) {
             })
             reply({projects: projectsData})
         });
+    }).catch(function(err) {
+        reply(Boom.badRequest(err));
     });
 }

--- a/server/controller/userController.js
+++ b/server/controller/userController.js
@@ -60,29 +60,38 @@ function updateGithubLogin(request, reply) {
 }
 
 function updateInfo(request, reply) {
-    var user_id = request.params.user_id;
-    var payload = {}
-    if (request.payload.display_name) {
-        payload.display_name = request.payload.display_name
-    }
-    if (request.payload.display_image) {
-        payload.display_image = request.payload.display_image
-    }
-    if (request.payload.email) {
-        payload.email = request.payload.email
-    }
-    if (request.payload.google_id) {
-        payload.google_id = request.payload.google_id
-    }
-    if (request.payload.github_login) {
-        payload.github_login = request.payload.github_login
+  const userId = request.params.user_id;
+  storage.findUserById(userId).then((user) => {
+    if (!user) {
+      reply(Boom.notFound());
+      return;
+    } if (request.payload === null) {
+      // Do nothing if no payload sent
+      reply({ status: constants.STATUS_OK });
+      return;
     }
 
-    storage.updateUser(user_id, payload).then(function() {
-        reply({
-            status: constants.STATUS_OK
-        });
-    })
+    const payload = {};
+    if (request.payload.display_name) {
+      payload.display_name = request.payload.display_name;
+    }
+    if (request.payload.display_image) {
+      payload.display_image = request.payload.display_image;
+    }
+    if (request.payload.email) {
+      payload.email = request.payload.email;
+    }
+    if (request.payload.google_id) {
+      payload.google_id = request.payload.google_id;
+    }
+    if (request.payload.github_login) {
+      payload.github_login = request.payload.github_login;
+    }
+
+    storage.updateUser(userId, payload).then(() => {
+      reply({ status: constants.STATUS_OK });
+    });
+  });
 }
 
 function normalize(projectsData) {

--- a/server/controller/userController.js
+++ b/server/controller/userController.js
@@ -15,25 +15,28 @@ var req = require("request")
 var _ = require('lodash');
 
 module.exports = {
-    getInfo: {
-        handler: populate
-    },
-    updateInfo: {
-        handler: updateInfo,
-        validate: {
-            params: {
-                user_id: Joi.string().required()
-            }
-        }
-    },
-    updateGithubLogin: {
-        handler: updateGithubLogin,
-        validate: {
-            params: {
-                user_id: Joi.string().required()
-            }
-        }
+  getInfo: {
+    handler: populate
+  },
+  updateInfo: {
+    handler: updateInfo,
+    validate: {
+      params: {
+        user_id: Joi.string().required()
+      }
     }
+  },
+  updateGithubLogin: {
+    handler: updateGithubLogin,
+    validate: {
+      params: {
+        user_id: Joi.string().required(),
+      },
+      payload: {
+        token: Joi.string().required(),
+      },
+    },
+  },
 };
 
 function updateGithubLogin(request, reply) {

--- a/server/data/storage.js
+++ b/server/data/storage.js
@@ -162,7 +162,7 @@ module.exports = {
         return new Promise(function(resolve, reject) {
             Task.findById(taskId).then(function (task) {
                 if (!task) {
-                    reject(taskId)
+                    reject(format(constants.TASK_NOT_EXIST, taskId))
                     return
                 }
                 Project.findById(task.project_id).then(function(project) {

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,6 +1,8 @@
-# Mocha discourages arrow callbacks. Here we override some of the rules to
-# allow for regular function callbacks.
+# Include a .eslintrc for the tests directory, unless someone
+# is willing to refactor and lint the rest of the codebase.
+# Mocha discourages arrow callbacks. Override some rules to allow regular function callbacks.
 {
+  "extends": "airbnb",
   "rules": {
     "prefer-arrow-callback": 0,
     "func-names": 0,

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,8 +1,14 @@
-# Include a .eslintrc for the tests directory, unless someone
-# is willing to refactor and lint the rest of the codebase.
+# Include a .eslintrc for the tests directory.
+#
 # Mocha discourages arrow callbacks. Override some rules to allow regular function callbacks.
+# This allows us to use the `this` context to share variables between `beforeEach()` and `it()` blocks.
+#
+# The alternative is to use `let user;` in the root of the `describe()` block and assign
+# `user = 'something';` in inner blocks. This works well, but I find it tends to get messy.
+#
+# Having a `this.user` prefix is more obvious when scanning code.
+# Thus the decision to stick with `function()` callbacks is simply choosing the lesser evil.
 {
-  "extends": "airbnb",
   "rules": {
     "prefer-arrow-callback": 0,
     "func-names": 0,

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,0 +1,9 @@
+# Mocha discourages arrow callbacks. Here we override some of the rules to
+# allow for regular function callbacks.
+{
+  "rules": {
+    "prefer-arrow-callback": 0,
+    "func-names": 0,
+    "space-before-function-paren": 0,
+  },
+}

--- a/tests/newsfeed.spec.js
+++ b/tests/newsfeed.spec.js
@@ -7,6 +7,16 @@ import constants from '../server/constants';
 import server from '../server/server';
 
 describe('Newsfeed', function() {
+  beforeEach(function(done) {
+    this.socketMock = sinon.mock(socket);
+    done();
+  });
+
+  afterEach(function(done) {
+    this.socketMock.restore();
+    done();
+  });
+
   it('should save newsfeed post to disk and broadcast to project', function(done) {
     const storageStub = sinon.stub(storage, 'saveNewsfeed');
     const data = { ref_type: 'branch', ref: 'helloworld', user_id: 'NysSbasYe' };
@@ -23,8 +33,7 @@ describe('Newsfeed', function() {
     storageStub.withArgs(JSON.stringify(data), template, projectId)
       .returns(Promise.resolve(newsfeedPost));
 
-    const socketMock = sinon.mock(socket);
-    socketMock
+    this.socketMock
       .expects('sendMessageToProject')
       .once()
       .withExactArgs(projectId, 'newsfeed_post', newsfeedPost);

--- a/tests/newsfeed.spec.js
+++ b/tests/newsfeed.spec.js
@@ -6,8 +6,8 @@ import socket from '../server/controller/socket/handlers';
 import constants from '../server/constants';
 import server from '../server/server';
 
-describe('Newsfeed', () => {
-  it('should save newsfeed post to disk and broadcast to project', (done) => {
+describe('Newsfeed', function() {
+  it('should save newsfeed post to disk and broadcast to project', function(done) {
     const storageStub = sinon.stub(storage, 'saveNewsfeed');
     const data = { ref_type: 'branch', ref: 'helloworld', user_id: 'NysSbasYe' };
     const template = templates.GITHUB_CREATE;
@@ -36,7 +36,7 @@ describe('Newsfeed', () => {
       });
   });
 
-  it('should get newsfeed posts', (done) => {
+  it('should get newsfeed posts', function(done) {
     const storageGetProjectsOfUser = sinon.stub(storage, 'getProjectsOfUser');
     const storageGetNewsfeed = sinon.stub(storage, 'getNewsfeed');
     const data = { ref_type: 'branch', ref: 'helloworld', user_id: 'NysSbasYe' };

--- a/tests/routes/milestone.spec.js
+++ b/tests/routes/milestone.spec.js
@@ -1,0 +1,133 @@
+/* global sinon, expect, beforeEach, afterEach, it, describe, context */
+import request from 'request';
+import github from '../../server/controller/githubController';
+import socket from '../../server/controller/socket/handlers';
+import constants from '../../server/constants';
+import server from '../../server/server';
+import models from '../../server/data/models/modelManager';
+
+describe('User', function() {
+  beforeEach(function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.socketMock = this.sandbox.mock(socket);
+    this.githubMock = this.sandbox.mock(github);
+
+    models.User
+      .create({
+        id: 'user1',
+        email: 'email1',
+        github_login: 'github_login1',
+      })
+      .then((newUser) => {
+        this.user = newUser;
+        return models.Project.create({
+          id: 'project1',
+          github_repo_owner: 'user1',
+          github_repo_name: 'repo_name',
+        });
+      })
+      .then((newProject) => {
+        this.project = newProject;
+        return this.user.addProject(newProject, { role: constants.ROLE_CREATOR });
+      })
+      .then(() => this.project.addUser(this.user))
+      .then(() => models.Milestone.create({
+        id: 'milestone1',
+        project_id: 'project1',
+        github_number: 1,
+      }))
+      .then((newMilestone) => {
+        this.milestone = newMilestone;
+        return models.Task.create({
+          id: 'task1',
+          project_id: 'project1',
+          milestone_id: 'milestone1',
+          github_token: 'github_token1',
+        });
+      })
+      .then((newTask) => {
+        this.task = newTask;
+        done();
+      });
+  });
+
+  afterEach(function(done) {
+    this.sandbox.restore();
+    done();
+  });
+
+  context('creating milestone', function() {
+    beforeEach(function(done) {
+      this.payload = {
+        content: 'created milestone content',
+        deadline: '2016-01-01 00:00:00',
+        project_id: this.project.id,
+      };
+      done();
+    });
+
+    it('should return 404 if user does not exist', function(done) {
+      server.select('api').inject({
+        method: 'POST',
+        url: '/milestones',
+        credentials: { user_id: 'user2', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(404);
+        done();
+      });
+    });
+
+    it('should create a local-only milestone if no github_token', function(done) {
+      server.select('api').inject({
+        method: 'POST',
+        url: '/milestones',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        this.githubMock.expects('createGithubMilestone').never();
+        models.Milestone
+          .findOne({ where: { content: this.payload.content } })
+          .then((result) => {
+            expect(result).is.not.a('null');
+            expect(result.content).is.equal(this.payload.content);
+          });
+        done();
+      });
+    });
+
+    it('should create a github milestone if github_token is provided', function(done) {
+      this.payload.github_token = 'github_token1';
+      server.select('api').inject({
+        method: 'POST',
+        url: '/milestones',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        const githubPayload = {
+          content: this.payload.content,
+          deadline: this.payload.deadline,
+          project_id: this.payload.project_id,
+        };
+        models.Milestone
+          .findOne({ where: { content: this.payload.content } })
+          .then((result) => {
+            expect(result).is.not.a('null');
+            expect(result.content).is.equal(this.payload.content);
+            this.githubMock.expects('createGithubMilestone')
+              .once()
+              .withExactArgs(
+                result.id,
+                githubPayload,
+                this.project.github_repo_owner,
+                this.project.github_repo_name,
+                this.payload.github_token
+              );
+          });
+        done();
+      });
+    });
+  });
+});

--- a/tests/routes/milestone.spec.js
+++ b/tests/routes/milestone.spec.js
@@ -5,7 +5,7 @@ import constants from '../../server/constants';
 import server from '../../server/server';
 import models from '../../server/data/models/modelManager';
 
-describe('User', function() {
+describe('Milestone', function() {
   beforeEach(function(done) {
     this.sandbox = sinon.sandbox.create();
     this.socketMock = this.sandbox.mock(socket);

--- a/tests/routes/newsfeed.spec.js
+++ b/tests/routes/newsfeed.spec.js
@@ -1,10 +1,10 @@
-/* global sinon, expect, beforeEach, afterEach, it, describe */
-import newsfeed from '../server/controller/newsfeedController';
-import storage from '../server/data/storage';
-import templates from '../server/templates';
-import socket from '../server/controller/socket/handlers';
-import constants from '../server/constants';
-import server from '../server/server';
+/* global sinon, expect, beforeEach, afterEach, it, describe, context */
+import newsfeed from '../../server/controller/newsfeedController';
+import storage from '../../server/data/storage';
+import templates from '../../server/templates';
+import socket from '../../server/controller/socket/handlers';
+import constants from '../../server/constants';
+import server from '../../server/server';
 
 describe('Newsfeed', function() {
   beforeEach(function(done) {

--- a/tests/routes/newsfeed.spec.js
+++ b/tests/routes/newsfeed.spec.js
@@ -8,17 +8,18 @@ import server from '../../server/server';
 
 describe('Newsfeed', function() {
   beforeEach(function(done) {
-    this.socketMock = sinon.mock(socket);
+    this.sandbox = sinon.sandbox.create();
+    this.socketMock = this.sandbox.mock(socket);
     done();
   });
 
   afterEach(function(done) {
-    this.socketMock.restore();
+    this.sandbox.restore();
     done();
   });
 
   it('should save newsfeed post to disk and broadcast to project', function(done) {
-    const storageStub = sinon.stub(storage, 'saveNewsfeed');
+    const storageStub = this.sandbox.stub(storage, 'saveNewsfeed');
     const data = { ref_type: 'branch', ref: 'helloworld', user_id: 'NysSbasYe' };
     const template = templates.GITHUB_CREATE;
     const projectId = '4yGslGste';
@@ -46,8 +47,8 @@ describe('Newsfeed', function() {
   });
 
   it('should get newsfeed posts', function(done) {
-    const storageGetProjectsOfUser = sinon.stub(storage, 'getProjectsOfUser');
-    const storageGetNewsfeed = sinon.stub(storage, 'getNewsfeed');
+    const storageGetProjectsOfUser = this.sandbox.stub(storage, 'getProjectsOfUser');
+    const storageGetNewsfeed = this.sandbox.stub(storage, 'getNewsfeed');
     const data = { ref_type: 'branch', ref: 'helloworld', user_id: 'NysSbasYe' };
     const userId = 'user1';
     const projectId = 'project1';

--- a/tests/routes/notification.spec.js
+++ b/tests/routes/notification.spec.js
@@ -1,0 +1,133 @@
+/* global sinon, expect, beforeEach, afterEach, it, describe, context */
+import Jwt from 'jsonwebtoken';
+import github from '../../server/controller/githubController';
+import socket from '../../server/controller/socket/handlers';
+import server from '../../server/server';
+import models from '../../server/data/models/modelManager';
+import config from 'config';
+
+describe('Notification', function() {
+  beforeEach(function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.socketMock = this.sandbox.mock(socket);
+    this.githubMock = this.sandbox.mock(github);
+
+    models.User
+      .create({
+        id: 'user1',
+        github_login: 'github_login1',
+      })
+      .then((newUser) => {
+        this.user = newUser;
+      })
+      .then(() => models.Project.create({
+        id: 'project1',
+        content: 'project content',
+        github_repo_owner: 'user1',
+        github_repo_name: 'repo_name',
+      }))
+      .then((newProject) => {
+        this.project = newProject;
+        return this.user.addProject(this.project);
+      })
+      .then(() => models.Notification.create({
+        id: 'notification1',
+        data: JSON.stringify({
+          user_id: this.user.id,
+          project_id: this.project.id,
+        }),
+        template: 'template1',
+        is_read: false,
+      }))
+      .then((newNotification) => {
+        this.notification = newNotification;
+        return this.user.addNotification(this.notification);
+      })
+      .then(() => {
+        done();
+      });
+  });
+
+  afterEach(function(done) {
+    this.sandbox.restore();
+    done();
+  });
+
+  context('getting notifications', function() {
+    beforeEach(function(done) {
+      const privateKey = config.get('authentication.privateKey');
+      this.tokenData = {
+        user_id: this.user.id,
+        expiresIn: 360,
+      };
+      this.token = Jwt.sign(this.tokenData, privateKey);
+      done();
+    });
+
+    it('should get a user\'s notifications', function(done) {
+      server.select('api').inject({
+        method: 'GET',
+        url: '/notifications',
+        credentials: { user_id: 'user1', password: 'password1' },
+        headers: {
+          authorization: `Token: ${this.token}`,
+        },
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        done();
+      });
+    });
+  });
+
+  context('removing notifications', function() {
+    it('should remove a notification', function(done) {
+      server.select('api').inject({
+        method: 'DELETE',
+        url: '/notification/notification1',
+        credentials: { user_id: 'user1', password: 'password1' },
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        models.Notification.findById('notification1').then(result => {
+          expect(result).to.be.a('null');
+          done();
+        });
+      });
+    });
+  });
+
+  context('updating notifications', function() {
+    beforeEach(function(done) {
+      this.payload = {
+        data: 'new notification data',
+      };
+      done();
+    });
+
+    it('should return 400 if missing params', function(done) {
+      server.select('api').inject({
+        method: 'PUT',
+        url: '/notification/notification1',
+        credentials: { user_id: 'user1', password: 'password1' },
+      }, (res) => {
+        expect(res.statusCode).to.equal(400);
+        done();
+      });
+    });
+
+    it('should update a notification', function(done) {
+      server.select('api').inject({
+        method: 'PUT',
+        url: '/notification/notification1',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        models.Notification.findById('notification1').then(result => {
+          expect(result).to.not.be.a('null');
+          expect(result.data).to.be.equal(this.payload.data);
+          done();
+        });
+      });
+    });
+  });
+});

--- a/tests/routes/project.spec.js
+++ b/tests/routes/project.spec.js
@@ -1,0 +1,206 @@
+/* global sinon, expect, beforeEach, afterEach, it, describe, context */
+import templates from '../../server/templates';
+import github from '../../server/controller/githubController';
+import notifications from '../../server/controller/notificationController';
+import socket from '../../server/controller/socket/handlers';
+import constants from '../../server/constants';
+import server from '../../server/server';
+import models from '../../server/data/models/modelManager';
+
+describe('Project', function() {
+  beforeEach(function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.socketMock = this.sandbox.mock(socket);
+    this.githubMock = this.sandbox.mock(github);
+
+    models.User
+      .create({
+        id: 'user1',
+        email: 'email1',
+        github_login: 'github_login1',
+      })
+      .then((newUser) => {
+        this.user = newUser;
+        return models.Project.create({
+          id: 'project1',
+          github_repo_owner: 'user1',
+          github_repo_name: 'repo_name',
+        });
+      })
+      .then((newProject) => {
+        this.project = newProject;
+        return this.user.addProject(newProject, { role: constants.ROLE_CREATOR });
+      })
+      .then(() => this.project.addUser(this.user))
+      .then(() => models.Milestone.create({
+        id: 'milestone1',
+        project_id: 'project1',
+        github_number: 1,
+      }))
+      .then((newMilestone) => {
+        this.milestone = newMilestone;
+        return models.Task.create({
+          id: 'task1',
+          project_id: 'project1',
+          milestone_id: 'milestone1',
+          github_token: 'github_token1',
+        });
+      })
+      .then((newTask) => {
+        this.task = newTask;
+        done();
+      });
+  });
+
+  afterEach(function(done) {
+    this.sandbox.restore();
+    done();
+  });
+
+  context('getting a single project', function() {
+    it('should return 403 is user is not authorized', function(done) {
+      server.select('api').inject({
+        method: 'GET',
+        url: '/project/project1',
+        credentials: { user_id: 'user2', password: 'password1' },
+      }, (res) => {
+        expect(res.statusCode).to.equal(403);
+        done();
+      });
+    });
+
+    it('should get a single project and its tasks', function(done) {
+      server.select('api').inject({
+        method: 'GET',
+        url: '/project/project1',
+        credentials: { user_id: 'user1', password: 'password1' },
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.result.tasks).to.be.a('array');
+        expect(res.result.tasks.length).to.equal(1);
+        expect(res.result.tasks[0].id).to.equal(this.task.id);
+        done();
+      });
+    });
+  });
+
+  context('creating projects', function() {
+    it('should return 400 if missing params', function(done) {
+      server.select('api').inject({
+        method: 'POST',
+        url: '/projects',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify({}),
+      }, (res) => {
+        expect(res.statusCode).to.equal(400);
+        done();
+      });
+    });
+
+    it('should create a project', function(done) {
+      server.select('api').inject({
+        method: 'POST',
+        url: '/projects',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify({ content: 'project content' }),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.have.any.keys('project_id');
+        const newProjectId = res.result.project_id;
+        models.Project.findById(newProjectId).then((result) => {
+          expect(result).to.not.be.a('null');
+          done();
+        });
+      });
+    });
+  });
+
+  context('inviting user to project', function() {
+    beforeEach(function(done) {
+      this.notificationsMock = this.sandbox.mock(notifications);
+      this.invitedEmail = 'invited@example.com';
+      this.payload = {
+        project_id: this.project.id,
+        email: this.invitedEmail,
+      };
+
+      models.User
+        .create({
+          id: 'user2',
+          email: this.invitedEmail,
+          github_login: 'github_login2',
+        })
+        .then((newUser) => {
+          this.user2 = newUser;
+          done();
+        });
+    });
+
+    it('should return 400 if invalid params', function(done) {
+      delete this.payload.project_id;
+      server.select('api').inject({
+        method: 'POST',
+        url: '/invite_to_project',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(400);
+        done();
+      });
+    });
+
+    it('should return 403 if user is not part of project', function(done) {
+      server.select('api').inject({
+        method: 'POST',
+        url: '/invite_to_project',
+        credentials: { user_id: 'user2', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(403);
+        done();
+      });
+    });
+
+    it('should return 400 if invited user does not exist', function(done) {
+      this.payload.email = 'nonexistent@example.com';
+      server.select('api').inject({
+        method: 'POST',
+        url: '/invite_to_project',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(400);
+        done();
+      });
+    });
+
+    it('should invite a user to the project', function(done) {
+      server.select('api').inject({
+        method: 'POST',
+        url: '/invite_to_project',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        const notificationData = {
+          user_id: 'user1',
+          project_id: this.project.id,
+        };
+        this.notificationsMock.expects('newUserNotification')
+          .withExactArgs(
+            notificationData, templates.INVITE_TO_PROJECT, this.user2.id
+          );
+        models.UserProject.findOne({
+          where: {
+            user_id: this.user2.id,
+            project_id: this.project.id,
+            role: constants.ROLE_PENDING,
+          },
+        }).then((result) => {
+          expect(result).to.not.be.a('null');
+          done();
+        });
+      });
+    });
+  });
+});

--- a/tests/routes/task.spec.js
+++ b/tests/routes/task.spec.js
@@ -353,7 +353,7 @@ describe('Task', function() {
       });
     });
 
-    it('should delete a task', function(done) {
+    it('should mark a task as done', function(done) {
       server.select('api').inject({
         method: 'POST',
         url: '/mark_completed',

--- a/tests/routes/task.spec.js
+++ b/tests/routes/task.spec.js
@@ -1,14 +1,15 @@
-/* global sinon, expect, beforeEach, afterEach, it, describe */
-import github from '../server/controller/githubController';
-import socket from '../server/controller/socket/handlers';
-import constants from '../server/constants';
-import server from '../server/server';
-import models from '../server/data/models/modelManager';
+/* global sinon, expect, beforeEach, afterEach, it, describe, context */
+import github from '../../server/controller/githubController';
+import socket from '../../server/controller/socket/handlers';
+import constants from '../../server/constants';
+import server from '../../server/server';
+import models from '../../server/data/models/modelManager';
 
 describe('Task', function() {
   beforeEach(function(done) {
-    this.socketMock = sinon.mock(socket);
-    this.githubMock = sinon.mock(github);
+    this.sandbox = sinon.sandbox.create();
+    this.socketMock = this.sandbox.mock(socket);
+    this.githubMock = this.sandbox.mock(github);
 
     models.User
       .create({
@@ -47,12 +48,11 @@ describe('Task', function() {
   });
 
   afterEach(function(done) {
-    this.socketMock.restore();
-    this.githubMock.restore();
+    this.sandbox.restore();
     done();
   });
 
-  describe('Get Tasks', function() {
+  context('getting tasks', function() {
     it('should return 400 if task does not exist', function(done) {
       server.select('api').inject({
         method: 'GET',
@@ -91,7 +91,7 @@ describe('Task', function() {
     });
   });
 
-  describe('Create Task', function() {
+  describe('creating tasks', function() {
     beforeEach(function(done) {
       this.payload = {
         content: 'task content',

--- a/tests/routes/task.spec.js
+++ b/tests/routes/task.spec.js
@@ -39,6 +39,7 @@ describe('Task', function() {
           id: 'task1',
           project_id: 'project1',
           milestone_id: 'milestone1',
+          github_token: 'github_token1',
         });
       })
       .then((newTask) => {
@@ -213,6 +214,156 @@ describe('Task', function() {
           );
         models.Task.findById('task1').then(createdTask => {
           expect(createdTask).to.not.be.a('null');
+          done();
+        });
+      });
+    });
+  });
+
+  describe('updating tasks', function() {
+    beforeEach(function(done) {
+      this.payload = {
+        content: 'new content',
+        project_id: this.task.project_id,
+      };
+      done();
+    });
+
+    it('should return 400 if task does not exist', function(done) {
+      server.select('api').inject({
+        method: 'PUT',
+        url: '/task/task999',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(400);
+        done();
+      });
+    });
+
+    it('should return 403 if user is not authorized', function(done) {
+      server.select('api').inject({
+        method: 'PUT',
+        url: '/task/task1',
+        credentials: { user_id: 'user22', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(403);
+        done();
+      });
+    });
+
+    it('should update a task', function(done) {
+      server.select('api').inject({
+        method: 'PUT',
+        url: '/task/task1',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        models.Task.findById('task1').then(fetchedTask => {
+          expect(fetchedTask).to.not.be.a('null');
+          expect(fetchedTask.content).to.be.equal(this.payload.content);
+          done();
+        });
+      });
+    });
+  });
+
+  describe('deleting tasks', function() {
+    beforeEach(function(done) {
+      this.payload = {
+        project_id: this.task.project_id,
+      };
+      done();
+    });
+
+    it('should return 400 if task does not exist', function(done) {
+      server.select('api').inject({
+        method: 'DELETE',
+        url: '/task/task999',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(400);
+        done();
+      });
+    });
+
+    it('should return 403 if user is not authorized', function(done) {
+      server.select('api').inject({
+        method: 'DELETE',
+        url: '/task/task1',
+        credentials: { user_id: 'user22', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(403);
+        done();
+      });
+    });
+
+    it('should delete a task', function(done) {
+      server.select('api').inject({
+        method: 'DELETE',
+        url: '/task/task1',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        models.Task.findById('task1').then(fetchedTask => {
+          expect(fetchedTask).to.be.a('null');
+          done();
+        });
+      });
+    });
+  });
+
+  describe('marking task as done', function() {
+    beforeEach(function(done) {
+      this.payload = {
+        task_id: this.task.id,
+        project_id: this.task.project_id,
+        github_token: this.task.github_token,
+      };
+      done();
+    });
+
+    it('should return 400 if task does not exist', function(done) {
+      this.payload.task_id = 'task999';
+      server.select('api').inject({
+        method: 'POST',
+        url: '/mark_completed',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(400);
+        done();
+      });
+    });
+
+    it('should return 403 if user is not authorized', function(done) {
+      server.select('api').inject({
+        method: 'POST',
+        url: '/mark_completed',
+        credentials: { user_id: 'user22', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(403);
+        done();
+      });
+    });
+
+    it('should delete a task', function(done) {
+      server.select('api').inject({
+        method: 'POST',
+        url: '/mark_completed',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        models.Task.findById('task1').then(fetchedTask => {
+          expect(fetchedTask).to.not.be.a('null');
+          expect(fetchedTask.completed_on).to.not.be.a('null');
           done();
         });
       });

--- a/tests/routes/user.spec.js
+++ b/tests/routes/user.spec.js
@@ -14,6 +14,7 @@ describe('User', function() {
     models.User
       .create({
         id: 'user1',
+        email: 'email1',
         github_login: 'github_login1',
       })
       .then((newUser) => {
@@ -81,6 +82,64 @@ describe('User', function() {
         expect(res.result.projects[0].milestones.length).to.equal(1);
         expect(res.result.projects[0].tasks.length).to.equal(1);
         done();
+      });
+    });
+  });
+
+  context('updating user', function() {
+    beforeEach(function(done) {
+      this.payload = {
+        display_name: 'new display name',
+        email: 'new email',
+        google_id: 'new google id',
+        github_login: 'new github login',
+      };
+      done();
+    });
+
+    it('should return 200 without updating if no payload', function(done) {
+      server.select('api').inject({
+        method: 'PUT',
+        url: '/user/user1',
+        credentials: { user_id: 'user1', password: 'password1' },
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        models.User.findById('user1').then(result => {
+          expect(result).to.not.be.a('null');
+          expect(result.email).to.be.equal(this.user.email);
+          done();
+        });
+      });
+    });
+
+    it('should return 404 if user does not exist', function(done) {
+      server.select('api').inject({
+        method: 'PUT',
+        url: '/user/user2',
+        credentials: { user_id: 'user2', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(404);
+        done();
+      });
+    });
+
+    it('should update a user', function(done) {
+      server.select('api').inject({
+        method: 'PUT',
+        url: '/user/user1',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        models.User.findById('user1').then(result => {
+          expect(result).to.not.be.a('null');
+          expect(result.display_name).to.be.equal(this.payload.display_name);
+          expect(result.email).to.be.equal(this.payload.email);
+          expect(result.google_id).to.be.equal(this.payload.google_id);
+          expect(result.github_login).to.be.equal(this.payload.github_login);
+          done();
+        });
       });
     });
   });

--- a/tests/routes/user.spec.js
+++ b/tests/routes/user.spec.js
@@ -1,0 +1,87 @@
+/* global sinon, expect, beforeEach, afterEach, it, describe, context */
+import github from '../../server/controller/githubController';
+import socket from '../../server/controller/socket/handlers';
+import constants from '../../server/constants';
+import server from '../../server/server';
+import models from '../../server/data/models/modelManager';
+
+describe('User', function() {
+  beforeEach(function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.socketMock = this.sandbox.mock(socket);
+    this.githubMock = this.sandbox.mock(github);
+
+    models.User
+      .create({
+        id: 'user1',
+        github_login: 'github_login1',
+      })
+      .then((newUser) => {
+        this.user = newUser;
+        return models.Project.create({
+          id: 'project1',
+          github_repo_owner: 'user1',
+          github_repo_name: 'repo_name',
+        });
+      })
+      .then((newProject) => {
+        this.project = newProject;
+        return this.user.addProject(newProject, { role: constants.ROLE_CREATOR });
+      })
+      .then(() => this.project.addUser(this.user))
+      .then(() => models.Milestone.create({
+        id: 'milestone1',
+        project_id: 'project1',
+        github_number: 1,
+      }))
+      .then((newMilestone) => {
+        this.milestone = newMilestone;
+        return models.Task.create({
+          id: 'task1',
+          project_id: 'project1',
+          milestone_id: 'milestone1',
+          github_token: 'github_token1',
+        });
+      })
+      .then((newTask) => {
+        this.task = newTask;
+        done();
+      });
+  });
+
+  afterEach(function(done) {
+    this.sandbox.restore();
+    done();
+  });
+
+  context('getting users', function() {
+    // NOTE: The route is weird in that the :user_id parameter isn't used.
+    // The user to get is actually taken from the credentials object.
+    it('should return 400 if user does not exist', function(done) {
+      server.select('api').inject({
+        method: 'GET',
+        url: '/user/populate/user2',
+        credentials: { user_id: 'user2', password: 'password1' },
+      }, (res) => {
+        expect(res.statusCode).to.equal(400);
+        done();
+      });
+    });
+
+    it('should get a user\'s projects', function(done) {
+      server.select('api').inject({
+        method: 'GET',
+        url: '/user/populate/user1',
+        credentials: { user_id: 'user1', password: 'password1' },
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.result.projects).to.be.a('array');
+        expect(res.result.projects.length).to.equal(1);
+        expect(res.result.projects[0].users.length).to.equal(1);
+        expect(res.result.projects[0].milestones.length).to.equal(1);
+        expect(res.result.projects[0].tasks.length).to.equal(1);
+        done();
+      });
+    });
+  });
+});

--- a/tests/routes/webhook.spec.js
+++ b/tests/routes/webhook.spec.js
@@ -1,7 +1,11 @@
 /* global sinon, expect, beforeEach, afterEach, it, describe, context */
 import events from 'events';
 import request from 'request';
+import constants from '../../server/constants';
 import server from '../../server/server';
+import models from '../../server/data/models/modelManager';
+import newsfeed from '../../server/controller/newsfeedController';
+import templates from '../../server/templates';
 
 describe('Webhook', function() {
   beforeEach(function(done) {
@@ -49,6 +53,101 @@ describe('Webhook', function() {
         expect(calledArgs.name).to.equal('web');
         expect(calledArgs.active).to.equal(true);
         done();
+      });
+    });
+  });
+
+  context('github webhook', function() {
+    beforeEach(function(done) {
+      this.newsfeedMock = this.sandbox.mock(newsfeed);
+
+      this.githubLogin = 'github_login1';
+      this.repoName = 'repo_name1';
+      this.repoOwner = 'owner1';
+
+      this.payload = {
+        sender: { login: this.githubLogin },
+        repository: {
+          name: this.repoName,
+          owner: { name: this.repoOwner },
+        },
+        commits: ['commit1'],
+        ref: '123456',
+        ref_type: 'branch',
+        release: 'release1',
+      };
+
+      models.User
+        .create({
+          id: 'user1',
+          email: 'email1',
+          github_login: this.githubLogin,
+        })
+        .then((newUser) => {
+          this.user = newUser;
+          return models.Project.create({
+            id: 'project1',
+            github_repo_owner: this.repoOwner,
+            github_repo_name: this.repoName,
+          });
+        })
+        .then((newProject) => {
+          this.project = newProject;
+          return this.user.addProject(newProject, { role: constants.ROLE_CREATOR });
+        })
+        .then(() => {
+          this.project.addUser(this.user);
+          done();
+        });
+    });
+
+
+    it('should handle a push event', function(done) {
+      this.newsfeedMock
+        .expects('updateNewsfeed')
+        .once()
+        .withArgs({ commitSize: 1, user_id: 'user1' }, templates.GITHUB_PUSH);
+      server.select('api').inject({
+        method: 'POST',
+        url: '/webhook/github',
+        credentials: { user_id: 'user1', password: 'password1' },
+        headers: {
+          'x-github-event': 'push',
+        },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        // Event handlers are executed async, so we have to wait a while before doing assertions.
+        setTimeout(() => {
+          this.newsfeedMock.verify();
+          done();
+        }, 200);
+      });
+    });
+
+    it('should handle a create event', function(done) {
+      this.newsfeedMock
+        .expects('updateNewsfeed')
+        .once()
+        .withArgs(
+          { ref: this.payload.ref, ref_type: this.payload.ref_type, user_id: 'user1' },
+          templates.GITHUB_CREATE
+        );
+      server.select('api').inject({
+        method: 'POST',
+        url: '/webhook/github',
+        credentials: { user_id: 'user1', password: 'password1' },
+        headers: {
+          'x-github-event': 'create',
+        },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        // Event handlers are executed async, so we have to wait a while before doing assertions.
+        setTimeout(() => {
+          this.newsfeedMock.verify();
+          done();
+        }, 200);
       });
     });
   });

--- a/tests/routes/webhook.spec.js
+++ b/tests/routes/webhook.spec.js
@@ -1,0 +1,55 @@
+/* global sinon, expect, beforeEach, afterEach, it, describe, context */
+import events from 'events';
+import request from 'request';
+import server from '../../server/server';
+
+describe('Webhook', function() {
+  beforeEach(function(done) {
+    this.sandbox = sinon.sandbox.create();
+    done();
+  });
+
+  afterEach(function(done) {
+    this.sandbox.restore();
+    done();
+  });
+
+  context('github webhook setup', function() {
+    beforeEach(function(done) {
+      this.payload = {
+        owner: 'owner1',
+        name: 'name1',
+        token: 'token1',
+      };
+      done();
+    });
+
+
+    it('should create github webhook', function(done) {
+      // Mock request.post().form().on('response', () => {})
+      // Kind of a hacky approach. Consider using something like nock.
+      const requestPostStub = this.sandbox.stub(request, 'post');
+      const formMock = this.sandbox.mock();
+      const emitter = new events.EventEmitter();
+      setTimeout(() => emitter.emit('response'), 200);
+      formMock.returns(emitter)
+        .once();
+      requestPostStub.returns({ form: formMock });
+
+      server.select('api').inject({
+        method: 'POST',
+        url: '/webhook/github/setup',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        formMock.verify();
+        const calledArgs = JSON.parse(formMock.args[0][0]);
+        expect(calledArgs.events).to.deep.equal(['create', 'push']);
+        expect(calledArgs.name).to.equal('web');
+        expect(calledArgs.active).to.equal(true);
+        done();
+      });
+    });
+  });
+});

--- a/tests/task.spec.js
+++ b/tests/task.spec.js
@@ -34,10 +34,42 @@ describe('Task', function() {
       });
   });
 
-  it('should get existing tasks', function(done) {
-    storage.getTask('task1').then((task1) => {
-      expect(task1.id).to.equal('task1');
-      done();
+  describe('Get Tasks', function() {
+    it('should return 400 if task does not exist', function(done) {
+      server.select('api').inject({
+        method: 'GET',
+        url: '/task/task999',
+        credentials: { user_id: 'user1', password: 'password1' },
+      }, (res) => {
+        expect(res.statusCode).to.equal(400);
+        done();
+      });
+    });
+
+    it('should return 403 if user is not authorized to view task\'s project', function(done) {
+      server.select('api').inject({
+        method: 'GET',
+        url: '/task/task1',
+        credentials: { user_id: 'user2', password: 'password1' },
+      }, (res) => {
+        expect(res.statusCode).to.equal(403);
+        done();
+      });
+    });
+
+    it('should get task', function(done) {
+      server.select('api').inject({
+        method: 'GET',
+        url: '/task/task1',
+        credentials: { user_id: 'user1', password: 'password1' },
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.be.a('object');
+        expect(res.result.id).to.equal('task1');
+        expect(res.result.project_id).to.equal('project1');
+        expect(res.result.milestone_id).to.equal('milestone1');
+        done();
+      });
     });
   });
 });

--- a/tests/task.spec.js
+++ b/tests/task.spec.js
@@ -9,27 +9,39 @@ describe('Task', function() {
   beforeEach(function(done) {
     this.socketMock = sinon.mock(socket);
     this.githubMock = sinon.mock(github);
-    let user = null;
 
     models.User
-      .create({ id: 'user1' })
+      .create({
+        id: 'user1',
+        github_login: 'github_login1',
+      })
       .then((newUser) => {
-        user = newUser;
+        this.user = newUser;
         return models.Project.create({
           id: 'project1',
+          github_repo_owner: 'user1',
+          github_repo_name: 'repo_name',
         });
       })
-      .then((newProject) => user.addProject(newProject, { role: constants.ROLE_CREATOR }))
+      .then((newProject) => {
+        this.project = newProject;
+        return this.user.addProject(newProject, { role: constants.ROLE_CREATOR });
+      })
       .then(() => models.Milestone.create({
         id: 'milestone1',
         project_id: 'project1',
+        github_number: 1,
       }))
-      .then(() => models.Task.create({
-        id: 'task1',
-        project_id: 'project1',
-        milestone_id: 'milestone1',
-      }))
-      .then(() => {
+      .then((newMilestone) => {
+        this.milestone = newMilestone;
+        return models.Task.create({
+          id: 'task1',
+          project_id: 'project1',
+          milestone_id: 'milestone1',
+        });
+      })
+      .then((newTask) => {
+        this.task = newTask;
         done();
       });
   });
@@ -81,7 +93,6 @@ describe('Task', function() {
 
   describe('Create Task', function() {
     beforeEach(function(done) {
-      this.socketMock = sinon.mock(socket);
       this.payload = {
         content: 'task content',
         project_id: 'project1',
@@ -115,7 +126,7 @@ describe('Task', function() {
       });
     });
 
-    it('should create a task without milestone', function(done) {
+    it('should create a task without github milestone/assignee', function(done) {
       server.select('api').inject({
         method: 'POST',
         url: '/tasks',
@@ -130,6 +141,76 @@ describe('Task', function() {
         this.githubMock
           .expects('createGithubIssue')
           .once();
+        models.Task.findById('task1').then(createdTask => {
+          expect(createdTask).to.not.be.a('null');
+          done();
+        });
+      });
+    });
+
+    it('should create a task with github milestone', function(done) {
+      this.payload.milestone_id = 'milestone1';
+
+      server.select('api').inject({
+        method: 'POST',
+        url: '/tasks',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        this.socketMock
+          .expects('sendMessageToProject')
+          .once()
+          .withArgs(this.payload.project_id, 'new_task');
+        const issue = {
+          title: this.payload.content,
+          milestone: this.milestone.github_number,
+        };
+        this.githubMock
+          .expects('createGithubIssue')
+          .once()
+          .withArgs(
+            this.project.github_repo_owner,
+            this.project.github_repo_name,
+            this.payload.request_token,
+            issue
+          );
+        models.Task.findById('task1').then(createdTask => {
+          expect(createdTask).to.not.be.a('null');
+          done();
+        });
+      });
+    });
+
+    it('should create a task with github milestone and assignee', function(done) {
+      this.payload.milestone_id = 'milestone1';
+      this.payload.assignee_id = 'user1';
+
+      server.select('api').inject({
+        method: 'POST',
+        url: '/tasks',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        this.socketMock
+          .expects('sendMessageToProject')
+          .once()
+          .withArgs(this.payload.project_id, 'new_task');
+        const issue = {
+          title: this.payload.content,
+          milestone: this.milestone.github_number,
+          assignee: this.user.github_login,
+        };
+        this.githubMock
+          .expects('createGithubIssue')
+          .once()
+          .withArgs(
+            this.project.github_repo_owner,
+            this.project.github_repo_name,
+            this.payload.request_token,
+            issue
+          );
         models.Task.findById('task1').then(createdTask => {
           expect(createdTask).to.not.be.a('null');
           done();

--- a/tests/task.spec.js
+++ b/tests/task.spec.js
@@ -8,8 +8,8 @@ import constants from '../server/constants';
 import server from '../server/server';
 import models from '../server/data/models/modelManager';
 
-describe('Task', () => {
-  beforeEach((done) => {
+describe('Task', function() {
+  beforeEach(function(done) {
     let user = null;
     models.User
       .create({ id: 'user1' })
@@ -34,7 +34,7 @@ describe('Task', () => {
       });
   });
 
-  it('should get existing tasks', (done) => {
+  it('should get existing tasks', function(done) {
     storage.getTask('task1').then((task1) => {
       expect(task1.id).to.equal('task1');
       done();

--- a/tests/task.spec.js
+++ b/tests/task.spec.js
@@ -1,16 +1,16 @@
 /* global sinon, expect, beforeEach, afterEach, it, describe */
-import Sequelize from 'sequelize';
-import task from '../server/controller/taskController';
-import storage from '../server/data/storage';
-// import templates from '../server/templates';
-// import socket from '../server/controller/socket/handlers';
+import github from '../server/controller/githubController';
+import socket from '../server/controller/socket/handlers';
 import constants from '../server/constants';
 import server from '../server/server';
 import models from '../server/data/models/modelManager';
 
 describe('Task', function() {
   beforeEach(function(done) {
+    this.socketMock = sinon.mock(socket);
+    this.githubMock = sinon.mock(github);
     let user = null;
+
     models.User
       .create({ id: 'user1' })
       .then((newUser) => {
@@ -32,6 +32,12 @@ describe('Task', function() {
       .then(() => {
         done();
       });
+  });
+
+  afterEach(function(done) {
+    this.socketMock.restore();
+    this.githubMock.restore();
+    done();
   });
 
   describe('Get Tasks', function() {
@@ -69,6 +75,65 @@ describe('Task', function() {
         expect(res.result.project_id).to.equal('project1');
         expect(res.result.milestone_id).to.equal('milestone1');
         done();
+      });
+    });
+  });
+
+  describe('Create Task', function() {
+    beforeEach(function(done) {
+      this.socketMock = sinon.mock(socket);
+      this.payload = {
+        content: 'task content',
+        project_id: 'project1',
+      };
+      done();
+    });
+
+    it('should return 403 if user is not a project member', function(done) {
+      this.payload.project_id = 'project2';
+      server.select('api').inject({
+        method: 'POST',
+        url: '/tasks',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(403);
+        done();
+      });
+    });
+
+    it('should return 400 if missing params', function(done) {
+      delete this.payload.content;
+      server.select('api').inject({
+        method: 'POST',
+        url: '/tasks',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(400);
+        done();
+      });
+    });
+
+    it('should create a task without milestone', function(done) {
+      server.select('api').inject({
+        method: 'POST',
+        url: '/tasks',
+        credentials: { user_id: 'user1', password: 'password1' },
+        payload: JSON.stringify(this.payload),
+      }, (res) => {
+        expect(res.statusCode).to.equal(200);
+        this.socketMock
+          .expects('sendMessageToProject')
+          .once()
+          .withArgs(this.payload.project_id, 'new_task');
+        this.githubMock
+          .expects('createGithubIssue')
+          .once();
+        models.Task.findById('task1').then(createdTask => {
+          expect(createdTask).to.not.be.a('null');
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
Contrary to the branch name, this branch implements tests for all the routes rather than tasks in particular.

- Add .eslintrc to the tests directory. Override some rules specifically for mocha tests. In particular, we don't want to enforce arrow-style function callbacks `() => {}` for mocha tests, since mocha tests use regular `function() {}` callbacks to preserve the `this` context.
- Add tasks for the following routes:

```javascript
    { method: 'POST',  path: '/tasks', config: Task.createTask },
    { method: 'GET',  path: '/task/{task_id}', config: Task.getTask },
    { method: 'PUT',  path: '/task/{task_id}', config: Task.updateTask },
    { method: 'POST',  path: '/mark_completed', config: Task.markComplete },
    { method: 'DELETE',  path: '/task/{task_id}', config: Task.removeTask },

    { method: 'POST',  path: '/milestones', config: Milestone.createMilestone },
    { method: 'PUT',  path: '/milestone/{milestone_id}', config: Milestone.updateMilestone },
    { method: 'DELETE',  path: '/milestone/{milestone_id}', config: Milestone.removeMilestone },

    { method: 'POST',  path: '/projects', config: Project.createProject },
    { method: 'POST',  path: '/invite_to_project', config: Project.inviteToProject },
    { method: 'GET',  path: '/project/{project_id}', config: Project.getProject },
    { method: 'PUT',  path: '/join_project/{project_id}', config: Project.acceptInvitation },
    { method: 'PUT',  path: '/decline_project/{project_id}', config: Project.declineInvitation },
    { method: 'PUT',  path: '/project/{project_id}', config: Project.updateProject },

    { method: 'GET',  path: '/user/populate/{user_id}', config: User.getInfo },
    { method: 'PUT',  path: '/user/{user_id}', config: User.updateInfo },
    { method: 'PUT',  path: '/user/github/{user_id}', config: User.updateGithubLogin },

    { method: 'GET',  path: '/notifications', config: Notification.getNotifications },
    { method: 'DELETE',  path: '/notification/{notification_id}', config: Notification.removeNotification },
    { method: 'PUT',  path: '/notification/{notification_id}', config: Notification.updateNotification },

    { method: 'POST',  path: '/newsfeed/{project_id}', config: Newsfeed.createPost },
    { method: 'GET',  path: '/newsfeed', config: Newsfeed.getNewsfeed }

    { method: 'POST',  path: '/webhook/github/setup', config: WebHook.setupGithubWebhook },
    { method: 'POST',  path: '/webhook/github', config: WebHook.githubWebhook },
```

This PR does not include tests for the following routes:

Omitting these routes due to difficulty properly stubbing out the analytics calls. Would rather not end up logging to the dashboard within tests.

```javascript
    { method: 'POST',  path: '/login', config: Auth.login },
    { method: 'POST',  path: '/refresh_google_token', config: Auth.refreshGoogleToken },

    { method: 'POST',  path: '/github/oauth/access_token', config: Github.getAccessToken },
    { method: 'POST',  path: '/github/sync/{project_id}', config: Github.sync },

    { method: 'POST',  path: '/webhook/drive', config: WebHook.googleDriveWebhook },
```

The route below doesn't seem functional. The serializer validates the existence of a `project_id` parameter as part of the route, but the route definition doesn't define one (eg. `/projects/{project_id}`). Will need further investigation if this route is deprecated, or if not, how it's meant to be invoked.

```javascript
{ method: 'GET',  path: '/projects', config: Project.getProjects },
```